### PR TITLE
teacher attrs, no reply email, editor rights

### DIFF
--- a/app/controllers/admin/teachers_controller.rb
+++ b/app/controllers/admin/teachers_controller.rb
@@ -55,7 +55,8 @@ module Admin
     # Only allow a trusted parameter "white list" through.
     def teacher_params
       params.require(:teacher).permit(
-        :first_name, :last_name, :profession, :title, address: %i[street zip city], contact: %i[email phone mobile fax]
+        :first_name, :last_name, :profession, :title, :skill_sets, :remarks,
+        address: %i[street zip city], contact: %i[email phone mobile fax]
       )
     end
   end

--- a/app/mailers/booking_mailer.rb
+++ b/app/mailers/booking_mailer.rb
@@ -3,7 +3,8 @@ class BookingMailer < ApplicationMailer
   def booking_confirmation_email(booking)
     @booking = booking
     @seminar = booking.seminar.decorate
-    mail(to: booking.contact_email, subject: 'Paritätische Bildungswerk Sachsen-Anhalt - Seminaranmeldung')
+    subject  = 'Paritätische Bildungswerk Sachsen-Anhalt - Seminaranmeldung'
+    mail to: booking.contact_email, subject: subject
   end
 
   def booking_notification_email(booking)

--- a/app/policies/category_policy.rb
+++ b/app/policies/category_policy.rb
@@ -1,4 +1,5 @@
 class CategoryPolicy < ApplicationPolicy
-  who_can(:index?) { editor? || layouter? }
-  who_can(:move?)  { update? }
+  who_can(:index?)  { editor? || layouter? }
+  who_can(:update?) { editor? }
+  who_can(:move?)   { update? }
 end

--- a/app/policies/location_policy.rb
+++ b/app/policies/location_policy.rb
@@ -1,3 +1,4 @@
 class LocationPolicy < ApplicationPolicy
+  who_can(:create?) { editor? }
   who_can(:update?) { editor? }
 end

--- a/app/views/booking_mailer/booking_confirmation_email.html.slim
+++ b/app/views/booking_mailer/booking_confirmation_email.html.slim
@@ -21,6 +21,10 @@ table
       - if @booking.contact_mobile.present?
         p #{@booking.contact_mobile} (Mobil)
 
+p Dies ist eine automatisch generierte E-Mail. Bitte ANTWORTEN SIE NICHT auf diese Mail, da die
+  Antwort NICHT ZUGESTELLT werden kann.
+p Für Rückfragen erreichen Sie uns unter: bildungswerk@paritaet-lsa.de
+
 p Freundliche Grüße <br> PARITÄTISCHES Bildungswerk <br> (PBW)
 
 .address

--- a/app/views/booking_mailer/booking_confirmation_email.text.erb
+++ b/app/views/booking_mailer/booking_confirmation_email.text.erb
@@ -6,6 +6,9 @@ hiermit bedanken wir uns für Ihre Anmeldung und übersenden Ihnen noch einmal z
 <%= Attendee.model_name.human(count: @booking.attendees.count) %>: <%= @booking.attendees.map(&:name).join(', ').html_safe %>
 Kontakt: <%= @booking.contact_email %>, <%= @booking.contact_phone %>, <%= @booking.contact_fax %> (Fax), <%= @booking.contact_mobile %> (Mobil)
 
+Dies ist eine automatisch generierte E-Mail. Bitte ANTWORTEN SIE NICHT auf diese Mail, da die Antwort NICHT ZUGESTELLT werden kann.
+Für Rückfragen erreichen Sie uns unter: bildungswerk@paritaet-lsa.de
+
 Freundliche Grüße
 PARITÄTISCHES Bildungswerk
 (PBW)


### PR DESCRIPTION
- add skill_sets and remarks to permitted attributes in teachers controller
- Info text "no reply email" on booking notification
- location and category rights for editors