### PR TITLE
Revert "Update rubyzip to version 1.2.2 (#221)"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -365,7 +365,7 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
-    rubyzip (1.2.2)
+    rubyzip (1.2.1)
     sass (3.7.3)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)


### PR DESCRIPTION
This reverts commit ff9cbdf42482610a222f5bd76ecf660b55806643.